### PR TITLE
Use service restart to improve compat. with next os version.

### DIFF
--- a/shared/dovecot/dovecot.sh
+++ b/shared/dovecot/dovecot.sh
@@ -11,7 +11,7 @@ else
     sudo touch /etc/dovecot/local.conf
     echo -e 'mail_location = mbox:~/mail' | sudo tee -a /etc/dovecot/local.conf
     echo -e 'disable_plaintext_auth = no' | sudo tee -a /etc/dovecot/local.conf
-    sudo restart dovecot
+    service dovecot restart
 fi
 
 #TODO

--- a/shared/vsftpd.sh
+++ b/shared/vsftpd.sh
@@ -6,5 +6,5 @@ if which vsftpd > /dev/null; then
 else
     sudo apt-get install -y vsftpd
     echo -e 'write_enable=YES' | sudo tee -a /etc/vsftpd.conf
-    sudo restart vsftpd
+    service vsftpd restart
 fi


### PR DESCRIPTION
Ubuntu 16.04 does not include upstart by default. Better to use 'service <name> restart' instead.